### PR TITLE
Fix incorrect method name

### DIFF
--- a/src/pages/api/bookmarks.js
+++ b/src/pages/api/bookmarks.js
@@ -4,5 +4,5 @@ import { getSettings } from "utils/config/config";
 
 export default async function handler(req, res) {
   const { provider, groups } = readIdentitySettings(getSettings().identity);
-  res.send(await bookmarksResponse(provider.authorize(req), groups));
+  res.send(await bookmarksResponse(provider.getIdentity(req), groups));
 }


### PR DESCRIPTION
## Proposed change

A function was renamed in e918c5284d95883bf751ac97dead2671c97a3017, but it looks like one usage of that was missed in that change.

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
