### PR TITLE
Parse allowUser/allowGroup from k8s annotations

### DIFF
--- a/docs/configs/kubernetes.md
+++ b/docs/configs/kubernetes.md
@@ -80,6 +80,8 @@ metadata:
     gethomepage.dev/pod-selector: ""
     gethomepage.dev/weight: 10 # optional
     gethomepage.dev/instance: "public" # optional
+    gethomepage.dev/allowUsers: user1,user2 # optional
+    gethomepage.dev/allowGroups: group1,group2 # optional
 spec:
   rules:
     - host: emby.example.com

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -286,6 +286,12 @@ export async function servicesFromKubernetes() {
         if (ingress.metadata.annotations[`${ANNOTATION_BASE}/statusStyle`]) {
           constructedService.statusStyle = ingress.metadata.annotations[`${ANNOTATION_BASE}/statusStyle`];
         }
+        if (ingress.metadata.annotations[`${ANNOTATION_BASE}/allowUsers`]) {
+          constructedService.allowUsers = ingress.metadata.annotations[`${ANNOTATION_BASE}/allowUsers`].split(",");
+        }
+        if (ingress.metadata.annotations[`${ANNOTATION_BASE}/allowGroups`]) {
+          constructedService.allowGroups = ingress.metadata.annotations[`${ANNOTATION_BASE}/allowGroups`].split(",");
+        }
         Object.keys(ingress.metadata.annotations).forEach((annotation) => {
           if (annotation.startsWith(ANNOTATION_WIDGET_BASE)) {
             shvl.set(


### PR DESCRIPTION
## Proposed change

Parse the `allowUsers` and `allowGroups` settings from Kubernetes annotations, allowing services discovered via that method to make use of identity based visibility.

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
