### PR TITLE
Make group header separator configurable

### DIFF
--- a/docs/configs/settings.md
+++ b/docs/configs/settings.md
@@ -494,7 +494,7 @@ If either value is set to true, the error message will be hidden.
 
 ## Identity Based Visibiltiy
 
-Basic user identity integration is implemeted via an `identity` section. An identity provider can be configured using the `provider` section with the given type. Currently the only provider supported is `proxy`, where the users identification and group membership are passed via HTTP Request headers (in plaintext). The expectation is that the application will be accessed only via an authenticating proxy (i.e traefik or nginx).
+Basic user identity integration is implemeted via an `identity` section. An identity provider can be configured using the `provider` section with the given type. Currently the only provider supported is `proxy`, where the users identification and group membership are passed via HTTP Request headers (in plaintext). The expectation is that the application will be accessed only via an authenticating proxy (i.e traefik or nginx). By default the list of groups will be split on `|`, but this can be changed.
 
 The group and user headers are both configurable like so:
 
@@ -503,6 +503,7 @@ identity:
   provider:
     type: proxy
     groupHeader: "X-group-header"
+    groupSeparator: "|"
     userHeader: "X-user-header"
 ```
 

--- a/src/utils/identity/proxy.js
+++ b/src/utils/identity/proxy.js
@@ -1,15 +1,15 @@
 // 'proxy' identity provider is meant to be used by a reverse proxy that injects permission headers into the origin
 // request. In this case we are relying on our proxy to authenitcate our users and validate their identity.
-function getProxyPermissions(userHeader, groupHeader, request) {
+function getProxyPermissions(userHeader, groupHeader, groupSeparator, request) {
   const user =
     userHeader && request.headers[userHeader.toLowerCase()] ? request.headers[userHeader.toLowerCase()] : null;
   const groupsString =
     groupHeader && request.headers[groupHeader.toLowerCase()] ? request.headers[groupHeader.toLowerCase()] : "";
 
-  return { user, groups: groupsString ? groupsString.split("|").map((v) => v.trim()) : [] };
+  return { user, groups: groupsString ? groupsString.split(groupSeparator ?? "|").map((v) => v.trim()) : [] };
 }
 
-function createProxyIdentity({ groupHeader, userHeader }) {
+function createProxyIdentity({ groupHeader, groupSeparator, userHeader }) {
   return {
     getContext: (request) => ({
       provider: "proxy",
@@ -18,7 +18,7 @@ function createProxyIdentity({ groupHeader, userHeader }) {
       ...(groupHeader &&
         request.headers[groupHeader] && { [groupHeader.toLowerCase()]: request.headers[groupHeader.toLowerCase()] }),
     }),
-    getIdentity: (request) => getProxyPermissions(userHeader, groupHeader, request),
+    getIdentity: (request) => getProxyPermissions(userHeader, groupHeader, groupSeparator, request),
   };
 }
 


### PR DESCRIPTION
## Proposed change

Make the separator used when parsing the group header configurable for wider compatibility.

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
